### PR TITLE
Add proper error types.

### DIFF
--- a/examples/easy_server.rs
+++ b/examples/easy_server.rs
@@ -1,14 +1,13 @@
 use std::env;
 use std::{future, net::SocketAddr, time::Duration};
 
-use esphome_native_api::esphomeapi::EspHomeApi;
-use esphome_native_api::parser::ProtoMessage;
-use esphome_native_api::proto::version_2025_12_1::ListEntitiesButtonResponse;
 use esphome_native_api::{
+    esphomeapi::EspHomeApi,
     esphomeserver::EspHomeServer,
-    proto::version_2025_12_1::{
-        ListEntitiesBinarySensorResponse, ListEntitiesLightResponse, ListEntitiesSensorResponse,
-        ListEntitiesSwitchResponse, SensorStateResponse,
+    parser::ProtoMessage,
+    proto::{
+        ListEntitiesBinarySensorResponse, ListEntitiesButtonResponse, ListEntitiesLightResponse,
+        ListEntitiesSensorResponse, ListEntitiesSwitchResponse, SensorStateResponse,
     },
 };
 use log::{LevelFilter, debug, info};

--- a/examples/encrypted_server.rs
+++ b/examples/encrypted_server.rs
@@ -1,12 +1,14 @@
 use std::env;
 use std::{future, net::SocketAddr, time::Duration};
 
-use esphome_native_api::esphomeapi::EspHomeApi;
-use esphome_native_api::parser::ProtoMessage;
-use esphome_native_api::proto::version_2025_12_1::ListEntitiesButtonResponse;
-use esphome_native_api::proto::version_2025_12_1::{
-    ListEntitiesBinarySensorResponse, ListEntitiesDoneResponse, ListEntitiesLightResponse,
-    ListEntitiesSensorResponse, ListEntitiesSwitchResponse, SensorStateResponse,
+use esphome_native_api::{
+    esphomeapi::EspHomeApi,
+    parser::ProtoMessage,
+    proto::{
+        ListEntitiesBinarySensorResponse, ListEntitiesButtonResponse, ListEntitiesDoneResponse,
+        ListEntitiesLightResponse, ListEntitiesSensorResponse, ListEntitiesSwitchResponse,
+        SensorStateResponse,
+    },
 };
 use log::{LevelFilter, debug, info};
 use tokio::{net::TcpSocket, signal, time::sleep};

--- a/examples/test_server.rs
+++ b/examples/test_server.rs
@@ -1,14 +1,14 @@
 use std::env;
 use std::{future, net::SocketAddr, time::Duration};
 
-use esphome_native_api::esphomeapi::EspHomeApi;
-use esphome_native_api::parser::ProtoMessage;
-use esphome_native_api::proto::version_2025_12_1::{
-    ListEntitiesBinarySensorResponse, ListEntitiesLightResponse, ListEntitiesSensorResponse,
-    ListEntitiesSwitchResponse, SensorStateResponse,
-};
-use esphome_native_api::proto::version_2025_12_1::{
-    ListEntitiesButtonResponse, ListEntitiesDoneResponse,
+use esphome_native_api::{
+    esphomeapi::EspHomeApi,
+    parser::ProtoMessage,
+    proto::{
+        ListEntitiesBinarySensorResponse, ListEntitiesButtonResponse, ListEntitiesDoneResponse,
+        ListEntitiesLightResponse, ListEntitiesSensorResponse, ListEntitiesSwitchResponse,
+        SensorStateResponse,
+    },
 };
 use log::{LevelFilter, debug, info};
 use tokio::{net::TcpSocket, signal, time::sleep};

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -100,9 +100,9 @@ async fn main() {
             }
 
             mod_file_content.push_str(&format!(
-                "#[cfg(feature = \"{}\")]\npub mod {};\n",
-                package_name, package_name
+                "\npub mod {package_name};\n#[cfg(feature = {package_name:?})]\npub use {package_name}::*;\n"
             ));
+
             let write_dir = root_output_dir.join(&package_name);
             fs::create_dir_all(&write_dir).unwrap();
 
@@ -141,8 +141,8 @@ async fn main() {
     file.seek(std::io::SeekFrom::Start(pos.try_into().unwrap()))
         .unwrap();
     writeln!(file, "[features]").unwrap();
-    let default_feature_flag = get_package_name(CURRENT_VERSION);
-    writeln!(file, "default = [\"std\", \"{}\"]", default_feature_flag).unwrap();
+    let default_package_name = get_package_name(CURRENT_VERSION);
+    writeln!(file, "default = [\"std\", \"{}\"]", default_package_name).unwrap();
     writeln!(file, "std = []").unwrap();
 
     for version in versions {

--- a/src/esphomeapi.rs
+++ b/src/esphomeapi.rs
@@ -29,7 +29,7 @@ use crate::frame::FrameCodec;
 use crate::packet_encrypted;
 use crate::packet_plaintext;
 use crate::parser::ProtoMessage;
-use crate::proto::{DeviceInfoResponse, DisconnectResponse, HelloResponse, PingResponse};
+use crate::proto::{self, DeviceInfoResponse, DisconnectResponse, HelloResponse, PingResponse};
 
 async fn write_error_and_disconnect(
     mut writer: FramedWrite<OwnedWriteHalf, FrameCodec>,
@@ -106,9 +106,6 @@ pub struct EspHomeApi {
     legacy_voice_assistant_version: u32,
     #[builder(default = 0)]
     voice_assistant_feature_flags: u32,
-
-    #[builder(default = "2025.4.0".to_string())]
-    esphome_version: String,
 }
 
 /// Handles the EspHome Api, with encryption etc.
@@ -135,7 +132,7 @@ impl EspHomeApi {
             uses_password: false,
             name: self.name.clone(),
             mac_address: self.mac.clone().unwrap_or_default(),
-            esphome_version: self.esphome_version.clone(),
+            esphome_version: proto::VERSION.to_owned(),
             compilation_time: self.compilation_time.clone().unwrap_or_default(),
             model: self.model.clone().unwrap_or_default(),
             has_deep_sleep: false,

--- a/src/esphomeapi.rs
+++ b/src/esphomeapi.rs
@@ -1,11 +1,3 @@
-use crate::frame::FrameCodec;
-use crate::packet_encrypted;
-use crate::packet_plaintext;
-use crate::parser::ProtoMessage;
-use crate::proto::version_2025_12_1::DeviceInfoResponse;
-use crate::proto::version_2025_12_1::DisconnectResponse;
-use crate::proto::version_2025_12_1::HelloResponse;
-use crate::proto::version_2025_12_1::PingResponse;
 use base64::prelude::*;
 use futures::sink::SinkExt;
 use log::debug;
@@ -32,6 +24,12 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::FramedWrite;
 use typed_builder::TypedBuilder;
+
+use crate::frame::FrameCodec;
+use crate::packet_encrypted;
+use crate::packet_plaintext;
+use crate::parser::ProtoMessage;
+use crate::proto::{DeviceInfoResponse, DisconnectResponse, HelloResponse, PingResponse};
 
 async fn write_error_and_disconnect(
     mut writer: FramedWrite<OwnedWriteHalf, FrameCodec>,

--- a/src/esphomeserver.rs
+++ b/src/esphomeserver.rs
@@ -1,9 +1,5 @@
 #![allow(dead_code)]
 
-use crate::esphomeapi::EspHomeApi;
-use crate::parser::ProtoMessage;
-
-use crate::proto::version_2025_12_1::ListEntitiesDoneResponse;
 use log::debug;
 use log::error;
 use noise_protocol::CipherState;
@@ -20,6 +16,10 @@ use tokio::sync::Mutex;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use typed_builder::TypedBuilder;
+
+use crate::esphomeapi::EspHomeApi;
+use crate::parser::ProtoMessage;
+use crate::proto::ListEntitiesDoneResponse;
 
 #[derive(TypedBuilder)]
 pub struct EspHomeServer {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     #[test_log::test]
     async fn hello_message_short() {
-        let hello_message = ProtoMessage::HelloResponse(proto::version_2025_12_1::HelloResponse {
+        let hello_message = ProtoMessage::HelloResponse(proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),
@@ -350,7 +350,7 @@ mod tests {
     #[test_log::test]
     async fn hello_message_short_encrypted() {
         // Arrange
-        let hello_message = ProtoMessage::HelloResponse(proto::version_2025_12_1::HelloResponse {
+        let hello_message = ProtoMessage::HelloResponse(proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),
@@ -387,7 +387,7 @@ mod tests {
         // Test that varint length encoding works correctly for long strings
 
         let hello_message = ProtoMessage::HelloResponse(
-            proto::version_2025_12_1::HelloResponse {
+            proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),
@@ -425,7 +425,7 @@ mod tests {
     #[test_log::test]
     async fn hello_message_overall_length_varint_longer() {
         let hello_message = ProtoMessage::HelloResponse(
-            proto::version_2025_12_1::HelloResponse {
+            proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),
@@ -462,7 +462,7 @@ mod tests {
     #[test_log::test]
     async fn hello_message_longer() {
         let hello_message: ProtoMessage = ProtoMessage::HelloResponse(
-            proto::version_2025_12_1::HelloResponse {
+            proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 
 pub mod proto;
 
-
-#[cfg(feature = "std")]
-pub mod parser;
 #[cfg(feature = "std")]
 pub mod esphomeapi;
 #[cfg(feature = "std")]
@@ -13,7 +10,8 @@ pub mod esphomeserver;
 mod frame;
 #[cfg(feature = "std")]
 mod packet_plaintext;
+#[cfg(feature = "std")]
+pub mod parser;
 // #[cfg(feature = "std")]
 #[cfg(feature = "std")]
 mod packet_encrypted;
-

--- a/src/packet_encrypted.rs
+++ b/src/packet_encrypted.rs
@@ -1,10 +1,11 @@
-use crate::parser;
-pub use crate::parser::ProtoMessage;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
 use log::debug;
 use noise_protocol::CipherState;
 use noise_rust_crypto::ChaCha20Poly1305;
+
+use crate::parser;
+pub use parser::ProtoMessage;
 
 pub fn generate_server_hello_frame(name: String, mac: Option<String>) -> Vec<u8> {
     let mut message_server_hello: Vec<u8> = Vec::new();
@@ -61,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_message_to_packet() {
-        let hello_message = ProtoMessage::HelloResponse(proto::version_2025_12_1::HelloResponse {
+        let hello_message = ProtoMessage::HelloResponse(proto::HelloResponse {
             api_version_major: 1,
             api_version_minor: 1,
             server_info: "Test Server".to_string(),

--- a/src/packet_plaintext.rs
+++ b/src/packet_plaintext.rs
@@ -1,6 +1,7 @@
-use crate::parser;
-pub use crate::parser::ProtoMessage;
 use log::debug;
+
+use crate::parser;
+pub use parser::ProtoMessage;
 
 pub fn packet_to_message(buffer: &[u8]) -> Result<ProtoMessage, Box<dyn std::error::Error>> {
     let message_type = buffer[0] as usize;
@@ -22,7 +23,7 @@ pub fn message_to_packet(message: &ProtoMessage) -> Result<Vec<u8>, Box<dyn std:
 mod tests {
     use test_log::test;
 
-    use crate::proto::version_2025_12_1::HelloRequest;
+    use crate::proto::HelloRequest;
 
     use super::*;
 

--- a/src/packet_plaintext.rs
+++ b/src/packet_plaintext.rs
@@ -4,16 +4,18 @@ use crate::parser;
 pub use parser::ProtoMessage;
 
 pub fn packet_to_message(buffer: &[u8]) -> Result<ProtoMessage, Box<dyn std::error::Error>> {
-    let message_type = buffer[0] as usize;
+    let message_type = buffer[0];
+    debug!("Message type: {message_type}");
+
     let packet_content = &buffer[1..];
-    debug!("Message type: {}", message_type);
-    debug!("Message: {:02X?}", packet_content);
-    Ok(parser::parse_proto_message(message_type, packet_content).unwrap())
+    debug!("Message: {packet_content:02X?}");
+
+    Ok(ProtoMessage::parse(message_type, packet_content).unwrap())
 }
 
 pub fn message_to_packet(message: &ProtoMessage) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let response_content = parser::proto_to_vec(message)?;
-    let message_type = parser::message_to_num(message)?;
+    let response_content = message.to_bytes();
+    let message_type = message.message_type();
     let message_bit: Vec<u8> = vec![message_type];
 
     Ok([message_bit, response_content].concat())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,45 +1,47 @@
-// TODO: Parser should part of the proto generator 
-use crate::proto::version_2025_12_1::{
-    AlarmControlPanelCommandRequest, AlarmControlPanelStateResponse, BinarySensorStateResponse,
-    BluetoothConnectionsFreeResponse, BluetoothDeviceClearCacheResponse,
-    BluetoothDeviceConnectionResponse, BluetoothDevicePairingResponse, BluetoothDeviceRequest,
-    BluetoothDeviceUnpairingResponse, BluetoothGattErrorResponse,
-    BluetoothGattGetServicesDoneResponse, BluetoothGattGetServicesRequest,
-    BluetoothGattGetServicesResponse, BluetoothGattNotifyDataResponse, BluetoothGattNotifyRequest,
-    BluetoothGattNotifyResponse, BluetoothGattReadDescriptorRequest, BluetoothGattReadRequest,
-    BluetoothGattReadResponse, BluetoothGattWriteDescriptorRequest, BluetoothGattWriteRequest,
-    BluetoothGattWriteResponse, BluetoothLeAdvertisementResponse,
-    BluetoothLeRawAdvertisementsResponse, ButtonCommandRequest, CameraImageRequest,
-    CameraImageResponse, ClimateCommandRequest, ClimateStateResponse, AuthenticationRequest,
-    AuthenticationResponse, CoverCommandRequest, CoverStateResponse, DateCommandRequest,
-    DateStateResponse, DateTimeCommandRequest, DateTimeStateResponse, DeviceInfoRequest,
-    DeviceInfoResponse, DisconnectRequest, DisconnectResponse, EventResponse,
-    ExecuteServiceRequest, FanCommandRequest, FanStateResponse, GetTimeRequest, GetTimeResponse,
-    HelloRequest, HelloResponse, HomeAssistantStateResponse,
-    LightCommandRequest, LightStateResponse, ListEntitiesAlarmControlPanelResponse,
-    ListEntitiesBinarySensorResponse, ListEntitiesButtonResponse, ListEntitiesCameraResponse,
-    ListEntitiesClimateResponse, ListEntitiesCoverResponse, ListEntitiesDateResponse,
-    ListEntitiesDateTimeResponse, ListEntitiesDoneResponse, ListEntitiesEventResponse,
-    ListEntitiesFanResponse, ListEntitiesLightResponse, ListEntitiesLockResponse,
-    ListEntitiesMediaPlayerResponse, ListEntitiesNumberResponse, ListEntitiesRequest,
-    ListEntitiesSelectResponse, ListEntitiesSensorResponse, ListEntitiesServicesResponse,
-    ListEntitiesSwitchResponse, ListEntitiesTextResponse, ListEntitiesTextSensorResponse,
-    ListEntitiesTimeResponse, ListEntitiesUpdateResponse, ListEntitiesValveResponse,
-    LockCommandRequest, LockStateResponse, MediaPlayerCommandRequest, MediaPlayerStateResponse,
-    NumberCommandRequest, NumberStateResponse, PingRequest, PingResponse, SelectCommandRequest,
-    SelectStateResponse, SensorStateResponse, SubscribeBluetoothConnectionsFreeRequest,
-    SubscribeBluetoothLeAdvertisementsRequest, SubscribeHomeAssistantStateResponse,
-    SubscribeHomeAssistantStatesRequest, SubscribeHomeassistantServicesRequest,
-    SubscribeLogsRequest, SubscribeLogsResponse, SubscribeStatesRequest,
-    SubscribeVoiceAssistantRequest, SwitchCommandRequest, SwitchStateResponse, TextCommandRequest,
-    TextSensorStateResponse, TextStateResponse, TimeCommandRequest, TimeStateResponse,
-    UnsubscribeBluetoothLeAdvertisementsRequest, UpdateCommandRequest, UpdateStateResponse,
-    ValveCommandRequest, ValveStateResponse, VoiceAssistantAnnounceFinished,
-    VoiceAssistantAnnounceRequest, VoiceAssistantAudio, VoiceAssistantConfigurationRequest,
-    VoiceAssistantConfigurationResponse, VoiceAssistantEventResponse, VoiceAssistantRequest,
-    VoiceAssistantResponse, VoiceAssistantSetConfiguration, VoiceAssistantTimerEventResponse,
-};
+// TODO: Parser should part of the proto generator
+
 use prost::Message;
+
+use crate::proto::{
+    AlarmControlPanelCommandRequest, AlarmControlPanelStateResponse, AuthenticationRequest,
+    AuthenticationResponse, BinarySensorStateResponse, BluetoothConnectionsFreeResponse,
+    BluetoothDeviceClearCacheResponse, BluetoothDeviceConnectionResponse,
+    BluetoothDevicePairingResponse, BluetoothDeviceRequest, BluetoothDeviceUnpairingResponse,
+    BluetoothGattErrorResponse, BluetoothGattGetServicesDoneResponse,
+    BluetoothGattGetServicesRequest, BluetoothGattGetServicesResponse,
+    BluetoothGattNotifyDataResponse, BluetoothGattNotifyRequest, BluetoothGattNotifyResponse,
+    BluetoothGattReadDescriptorRequest, BluetoothGattReadRequest, BluetoothGattReadResponse,
+    BluetoothGattWriteDescriptorRequest, BluetoothGattWriteRequest, BluetoothGattWriteResponse,
+    BluetoothLeAdvertisementResponse, BluetoothLeRawAdvertisementsResponse, ButtonCommandRequest,
+    CameraImageRequest, CameraImageResponse, ClimateCommandRequest, ClimateStateResponse,
+    CoverCommandRequest, CoverStateResponse, DateCommandRequest, DateStateResponse,
+    DateTimeCommandRequest, DateTimeStateResponse, DeviceInfoRequest, DeviceInfoResponse,
+    DisconnectRequest, DisconnectResponse, EventResponse, ExecuteServiceRequest, FanCommandRequest,
+    FanStateResponse, GetTimeRequest, GetTimeResponse, HelloRequest, HelloResponse,
+    HomeAssistantStateResponse, LightCommandRequest, LightStateResponse,
+    ListEntitiesAlarmControlPanelResponse, ListEntitiesBinarySensorResponse,
+    ListEntitiesButtonResponse, ListEntitiesCameraResponse, ListEntitiesClimateResponse,
+    ListEntitiesCoverResponse, ListEntitiesDateResponse, ListEntitiesDateTimeResponse,
+    ListEntitiesDoneResponse, ListEntitiesEventResponse, ListEntitiesFanResponse,
+    ListEntitiesLightResponse, ListEntitiesLockResponse, ListEntitiesMediaPlayerResponse,
+    ListEntitiesNumberResponse, ListEntitiesRequest, ListEntitiesSelectResponse,
+    ListEntitiesSensorResponse, ListEntitiesServicesResponse, ListEntitiesSwitchResponse,
+    ListEntitiesTextResponse, ListEntitiesTextSensorResponse, ListEntitiesTimeResponse,
+    ListEntitiesUpdateResponse, ListEntitiesValveResponse, LockCommandRequest, LockStateResponse,
+    MediaPlayerCommandRequest, MediaPlayerStateResponse, NumberCommandRequest, NumberStateResponse,
+    PingRequest, PingResponse, SelectCommandRequest, SelectStateResponse, SensorStateResponse,
+    SubscribeBluetoothConnectionsFreeRequest, SubscribeBluetoothLeAdvertisementsRequest,
+    SubscribeHomeAssistantStateResponse, SubscribeHomeAssistantStatesRequest,
+    SubscribeHomeassistantServicesRequest, SubscribeLogsRequest, SubscribeLogsResponse,
+    SubscribeStatesRequest, SubscribeVoiceAssistantRequest, SwitchCommandRequest,
+    SwitchStateResponse, TextCommandRequest, TextSensorStateResponse, TextStateResponse,
+    TimeCommandRequest, TimeStateResponse, UnsubscribeBluetoothLeAdvertisementsRequest,
+    UpdateCommandRequest, UpdateStateResponse, ValveCommandRequest, ValveStateResponse,
+    VoiceAssistantAnnounceFinished, VoiceAssistantAnnounceRequest, VoiceAssistantAudio,
+    VoiceAssistantConfigurationRequest, VoiceAssistantConfigurationResponse,
+    VoiceAssistantEventResponse, VoiceAssistantRequest, VoiceAssistantResponse,
+    VoiceAssistantSetConfiguration, VoiceAssistantTimerEventResponse,
+};
 
 macro_rules! proto_message_mappings {
     ($($type_id:expr => $struct:ident),* $(,)?) => {
@@ -67,7 +69,7 @@ macro_rules! proto_message_mappings {
             match message {
                 $(
                     ProtoMessage::$struct(msg) => {
-                        
+
                         Ok(msg.encode_to_vec())
                     }
                 )*


### PR DESCRIPTION
Replace `Box<dyn std::error::Error>` with proper error types. Also avoids using `Box::leak` just to return a `&'static str` error.
